### PR TITLE
Add Rijksmuseum search page

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -51,3 +51,12 @@ $on-laptop:        800px;
         "layout",
         "syntax-highlighting"
 ;
+// Styles for Rijksmuseum search page
+.result-item {
+  margin-bottom: 20px;
+}
+.result-item img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}

--- a/js/rijksmuseum-search.js
+++ b/js/rijksmuseum-search.js
@@ -1,0 +1,40 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const form = document.getElementById('search-form');
+  const resultsContainer = document.getElementById('results');
+
+  form.addEventListener('submit', async function(event) {
+    event.preventDefault();
+    const key = document.getElementById('api-key').value.trim();
+    const query = document.getElementById('query').value.trim();
+    resultsContainer.innerHTML = '';
+
+    if (!key || !query) {
+      resultsContainer.textContent = 'Please enter both API key and query.';
+      return;
+    }
+
+    const url = `https://www.rijksmuseum.nl/api/en/collection?key=${encodeURIComponent(key)}&format=json&q=${encodeURIComponent(query)}`;
+
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error('Network response was not ok');
+      }
+      const data = await response.json();
+      if (data.artObjects && data.artObjects.length) {
+        data.artObjects.forEach(obj => {
+          const item = document.createElement('div');
+          item.className = 'result-item';
+          const img = obj.webImage ? `<img src="${obj.webImage.url}" alt="${obj.title}">` : '';
+          item.innerHTML = `<h3>${obj.title}</h3>${img}`;
+          resultsContainer.appendChild(item);
+        });
+      } else {
+        resultsContainer.textContent = 'No results found.';
+      }
+    } catch (err) {
+      console.error(err);
+      resultsContainer.textContent = 'Error fetching data.';
+    }
+  });
+});

--- a/search.html
+++ b/search.html
@@ -1,0 +1,19 @@
+---
+layout: default
+title: Rijksmuseum Search
+---
+
+<h1 class="page-heading">Rijksmuseum Search</h1>
+<div id="search-app">
+  <form id="search-form">
+    <label for="api-key">API Key:</label>
+    <input type="text" id="api-key" required placeholder="Enter your API key">
+    <label for="query">Query:</label>
+    <input type="text" id="query" required placeholder="Search term">
+    <button type="submit">Search</button>
+  </form>
+  <div id="results"></div>
+</div>
+
+<script src="{{ '/js/rijksmuseum-search.js' | prepend: site.baseurl }}"></script>
+


### PR DESCRIPTION
## Summary
- add minimal JS search interface for the Rijksmuseum API
- include a new page linking to the script
- style search results

## Testing
- `jekyll --version` *(fails: command not found)*